### PR TITLE
Add whitelist cleanup script

### DIFF
--- a/PSD_WHITELIST_CLEAN.lsp
+++ b/PSD_WHITELIST_CLEAN.lsp
@@ -1,0 +1,53 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Script Name : PSD_WHITELIST_CLEAN.lsp
+;; Version     : v1
+;; Author      : zhengqiao.sun@hsbcad.com
+;; Date        : 23.05.2025
+;; Description : Entfernt alle Property-Set-Definitions, die nicht in der
+;;               Whitelist enthalten sind.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; PSD_WHITELIST_CLEAN.lsp  ——  清理白名单之外的 Property-Set-Definitions（德语界面）
+(vl-load-com)
+
+;— 取得 PSD 字典 & 列表 ————————————————————
+(defun _dict ()
+  (vl-catch-all-apply
+    '(lambda ()
+       (vla-item
+         (vlax-ename->vla-object (namedobjdict))
+         "AEC_PROPERTY_SET_DEFS"))))
+
+(defun _names (/ d lst)
+  (if (setq d (_dict))
+    (vlax-for x d (setq lst (cons (vla-get-name x) lst))))
+  lst)
+
+;— 清理一个 PSD —————————————————————————
+(defun _zap (nm / d o)
+  (vl-cmdf "_.PROPERTYSETCLEAN" nm "")     ;删对象数据
+  (if (setq d (_dict))
+    (vl-catch-all-apply
+      '(lambda () (setq o (vla-item d nm)) (vla-delete o)))))
+
+;— 主命令 ——————————————————————————————
+(defun c:PSDBEREINIG (/ all keepList)
+  (setq keepList
+    '("2dBlock" "AecPolygonStil" "Dachelementstil" "Decke" "Deckenelemente"
+      "Deckenstil" "Dichte" "Fassadenstil" "Fenster" "Fensterstil"
+      "Geländerstil" "hsbPlatte" "hsbResponsibilitySet" "hsbStab"
+      "Multiwand" "RaumRubner" "Raumstil" "RubnerPolylinien"
+      "Tragwerkstil" "Treppe" "Treppenstil" "Türen" "Türstil"
+      "Wand" "Wandstil"))
+  (setq all (_names))
+  (if (null all)
+    (princ "\n=> Keine Property-Set-Definitionen in dieser Zeichnung.")
+    (progn
+      (foreach nm all
+        (if (not (member nm keepList))
+          (_zap nm)))
+      (princ "\n✔ Bereinigung abgeschlossen.")))
+  (princ))
+
+(princ "\nPSDBEREINIG geladen – Befehl PSDBEREINIG eingeben.\n")
+(princ)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,12 @@ AutoLISP scripts to identify and remove duplicate Property Set Definitions (PSDs
 - `PSDDEDUP v8.lsp` – Chinese user interface.
 - `PSDDEDUP_EN.lsp` – English user interface.
 - `需求文档.txt` – project requirements (Chinese).
+- `PSD_WHITELIST_CLEAN.lsp` – German script to remove all Property Set
+  Definitions not in the internal whitelist.
 
-Load either script with `APPLOAD` then run `PSDDEDUP` or `PSDDEDUP_EN`.
+Load the duplicate-removal scripts with `APPLOAD` then run `PSDDEDUP` or
+`PSDDEDUP_EN`. Lade `PSD_WHITELIST_CLEAN.lsp` und f\u00fchre `PSDBEREINIG`
+aus, um Property Set Definitions au\u00dferhalb der Whitelist zu entfernen.
 
 ## Usage
 Detailed instructions are available in:


### PR DESCRIPTION
## Summary
- add `PSD_WHITELIST_CLEAN.lsp` to delete all PSDs not in a preset whitelist
- document the new script in `README.md`
- rename the cleanup command from `PSDWHITELISTCLEAN` to `PSDBEREINIG`

## Testing
- `git status --short`
