### PR TITLE
Fix umlaut handling in whitelist clean script

### DIFF
--- a/PSD_WHITELIST_CLEAN.lsp
+++ b/PSD_WHITELIST_CLEAN.lsp
@@ -32,12 +32,20 @@
 
 ;— 主命令 ——————————————————————————————
 (defun c:PSDCLEAN (/ all keepList)
+  ;; Einige AutoCAD-Versionen können UTF-8 kodierte Umlaute nicht korrekt
+  ;; einlesen.  Dadurch wurden PSD-Namen mit Umlauten trotz Whitelist
+  ;; gelöscht.  Die Namen werden deshalb ohne UTF-8 Zeichen definiert und die
+  ;; Umlaute zur Laufzeit über `chr` zusammengesetzt.
   (setq keepList
-    '("2dBlock" "AecPolygonStil" "Dachelementstil" "Decke" "Deckenelemente"
+    (list
+      "2dBlock" "AecPolygonStil" "Dachelementstil" "Decke" "Deckenelemente"
       "Deckenstil" "Dichte" "Fassadenstil" "Fenster" "Fensterstil"
-      "Geländerstil" "hsbPlatte" "hsbResponsibilitySet" "hsbStab"
+      (strcat "Gel" (chr 228) "nderstil")
+      "hsbPlatte" "hsbResponsibilitySet" "hsbStab"
       "Multiwand" "RaumRubner" "Raumstil" "RubnerPolylinien"
-      "Tragwerkstil" "Treppe" "Treppenstil" "Türen" "Türstil"
+      "Tragwerkstil" "Treppe" "Treppenstil"
+      (strcat "T" (chr 252) "ren")
+      (strcat "T" (chr 252) "rstil")
       "Wand" "Wandstil"))
   (setq all (_names))
   (if (null all)


### PR DESCRIPTION
## Summary
- fix UTF-8 umlaut handling in `PSD_WHITELIST_CLEAN.lsp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684fcb6494b4832f9caa14d609873b98