### PR TITLE
Fix PSDUPDATE dictionary lookup

### DIFF
--- a/PSD_PSET_UPDATE.lsp
+++ b/PSD_PSET_UPDATE.lsp
@@ -9,11 +9,16 @@
 (vl-load-com)
 
 ;;--- Utility: obtain the property set definition dictionary of a document -----
-(defun _psd-dict (doc / nod)
-  (vl-catch-all-apply
-    '(lambda ()
-       (setq nod (vla-get-NamedObjectsDictionary doc))
-       (vla-Item nod "AEC_PROPERTY_SET_DEFS")))
+(defun _psd-dict (doc / nod res)
+  ;; Return the property set definition dictionary of DOC
+  ;; or NIL if the dictionary doesn't exist
+  (setq res
+    (vl-catch-all-apply
+      '(lambda ()
+         (setq nod (vla-get-NamedObjectsDictionary doc))
+         (vla-Item nod "AEC_PROPERTY_SET_DEFS")))
+  )
+  (if (vl-catch-all-error-p res) nil res)
 )
 
 ;;--- Copy or replace a definition by name ------------------------------------


### PR DESCRIPTION
## Summary
- return NIL if the property set definition dictionary is missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685135c6935c832f80d955f01d36a8e2