### PR TITLE
Gracefully handle DWGCODEPAGE variable

### DIFF
--- a/PSD_PSET_UPDATE.lsp
+++ b/PSD_PSET_UPDATE.lsp
@@ -42,8 +42,11 @@
         dstDoc (vla-get-ActiveDocument app))
   ;; Ensure the drawing uses the Windows Latin-1 code page so that
   ;; property set names containing characters such as öäüß are handled
-  ;; correctly when copied from the template
-  (setvar "DWGCODEPAGE" "ANSI_1252")
+  ;; correctly when copied from the template.  Some drawings don't
+  ;; allow this system variable to be changed, so ignore any failure.
+  (if (/= (strcase (getvar "DWGCODEPAGE")) "ANSI_1252")
+    (vl-catch-all-apply
+      'setvar (list "DWGCODEPAGE" "ANSI_1252")))
   (if (findfile srcPath)
     (progn
       (setq srcDoc (vla-Open docs srcPath))


### PR DESCRIPTION
## Summary
- ignore errors when DWGCODEPAGE cannot be changed in PSD_PSET_UPDATE.lsp

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685148e8a578832f82ba741bcfc82ee5